### PR TITLE
update travis test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: node_js
 node_js:
-  - "0.12"
-  - "0.11"
-  - "0.10"
+- '0.10'
+- '0.12'
+- '4.2'
+- '5'
+matrix:
+  allow_failure:
+  - node_js: '5'
+sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ node_js:
 - '4.2'
 - '5'
 matrix:
-  allow_failure:
+  allow_failures:
   - node_js: '5'
 sudo: false


### PR DESCRIPTION
test on node `4.2` and `5` (ignoring `5` failures), and drop `0.11`
